### PR TITLE
Copy commit hash on shift+click

### DIFF
--- a/lib/blame-status-bar-view.js
+++ b/lib/blame-status-bar-view.js
@@ -57,6 +57,9 @@ class BlameStatusBarView extends HTMLElement {
     this.editorDisposables.dispose();
     this.renderDisposables.dispose();
     this.disposables.dispose();
+    if (this.tooltip) {
+      this.tooltip.dispose();
+    }
   }
 
   get editor() { // eslint-disable-line

--- a/lib/blame-status-bar-view.js
+++ b/lib/blame-status-bar-view.js
@@ -99,8 +99,9 @@ class BlameStatusBarView extends HTMLElement {
       this.innerHTML = data.html;
       this.hash = data.hash;
       if (utils.isCommitted(data.hash)) {
-        const tooltip = await this.addTooltip(data.hash);
-        this.renderDisposables.add(tooltip);
+        this.registerTooltip();
+      } else if (this.tooltip) {
+        this.tooltip.dispose();
       }
     } else if (this.hasGitRepo) {
       // No data available for current file
@@ -108,6 +109,15 @@ class BlameStatusBarView extends HTMLElement {
     } else {
       // No git repo for current file
       this.innerHTML = '';
+    }
+  }
+
+  async registerTooltip() {
+    if (this.tooltip) {
+      this.tooltip.dispose();
+    }
+    if (this.hash) {
+      this.tooltip = await this.addTooltip(this.hash);
     }
   }
 
@@ -143,16 +153,32 @@ class BlameStatusBarView extends HTMLElement {
     });
   }
 
-  async onLinkClicked() {
+  async onLinkClicked(event) {
     if (!utils.isCommitted(this.hash)) {
       return null;
     }
+
+    if (event.shiftKey) {
+      this.copyCommitHash();
+    } else {
+      await this.openCommitInBrowser();
+    }
+    return null;
+  }
+
+  async openCommitInBrowser() {
     const link = await utils.getCommitLink(this.editor.getPath(), this.hash.replace(/^[\^]/, ''));
     if (link) {
-      return open(link);
+      open(link);
+    } else {
+      atom.notifications.addInfo('Unknown url.');
     }
-    atom.notifications.addInfo('Unknown url.');
-    return null;
+  }
+
+  copyCommitHash() {
+    const shortHash = this.hash.substring(0, 8);
+    atom.clipboard.write(shortHash);
+    this.addCopiedTooltip(shortHash);
   }
 
   async addTooltip(hash) {
@@ -161,6 +187,22 @@ class BlameStatusBarView extends HTMLElement {
     return atom.tooltips.add(this, {
       title: formatTooltip(msg),
     });
+  }
+
+  addCopiedTooltip(hash) {
+    if (this.tooltip) {
+      this.tooltip.dispose();
+    }
+
+    const copiedTooltip = atom.tooltips.add(this, {
+      title: `Copied commit hash: ${hash}`,
+      trigger: 'manual',
+    });
+
+    setTimeout(() => {
+      copiedTooltip.dispose();
+      this.registerTooltip();
+    }, 1500);
   }
 }
 

--- a/lib/blame-status-bar-view.js
+++ b/lib/blame-status-bar-view.js
@@ -95,11 +95,8 @@ class BlameStatusBarView extends HTMLElement {
       }
       this.innerHTML = data.html;
       this.hash = data.hash;
-      if (utils.isCommitted(data.hash)) {
-        this.registerTooltip();
-      } else if (this.tooltip) {
-        this.disposeTooltip();
-      }
+
+      this.registerTooltip();
     } else if (this.hasGitRepo) {
       // No data available for current file
       this.innerHTML = 'Not Committed Yet';
@@ -111,7 +108,7 @@ class BlameStatusBarView extends HTMLElement {
 
   async registerTooltip() {
     this.disposeTooltip();
-    if (this.hash) {
+    if (this.hash && utils.isCommitted(this.hash)) {
       this.tooltip = await this.addTooltip(this.hash);
     }
   }

--- a/lib/blame-status-bar-view.js
+++ b/lib/blame-status-bar-view.js
@@ -41,7 +41,6 @@ class BlameStatusBarView extends HTMLElement {
   init() {
     this.classList.add('inline-block');
     this.editorDisposables = new CompositeDisposable();
-    this.renderDisposables = new CompositeDisposable();
 
     this.disposables = new CompositeDisposable();
     this.disposables.add(
@@ -55,11 +54,8 @@ class BlameStatusBarView extends HTMLElement {
 
   dispose() {
     this.editorDisposables.dispose();
-    this.renderDisposables.dispose();
+    this.disposeTooltip();
     this.disposables.dispose();
-    if (this.tooltip) {
-      this.tooltip.dispose();
-    }
   }
 
   get editor() { // eslint-disable-line
@@ -68,7 +64,7 @@ class BlameStatusBarView extends HTMLElement {
 
   async initEditor() {
     this.editorDisposables.dispose();
-    this.renderDisposables.dispose();
+    this.disposeTooltip();
     if (!this.editor) {
       return;
     }
@@ -79,7 +75,6 @@ class BlameStatusBarView extends HTMLElement {
 
     // Renew listeners
     this.editorDisposables = new CompositeDisposable();
-    this.renderDisposables = new CompositeDisposable();
     this.editorDisposables.add(
       this.editor.onDidChangeCursorPosition(this.onDidChangeCursorPosition.bind(this)),
     );
@@ -90,8 +85,7 @@ class BlameStatusBarView extends HTMLElement {
   }
 
   async render(row) {
-    this.renderDisposables.dispose();
-    this.renderDisposables = new CompositeDisposable();
+    this.disposeTooltip();
     if (this.blameData) {
       const data = this.blameData[row];
       if (!data) {
@@ -104,7 +98,7 @@ class BlameStatusBarView extends HTMLElement {
       if (utils.isCommitted(data.hash)) {
         this.registerTooltip();
       } else if (this.tooltip) {
-        this.tooltip.dispose();
+        this.disposeTooltip();
       }
     } else if (this.hasGitRepo) {
       // No data available for current file
@@ -116,11 +110,16 @@ class BlameStatusBarView extends HTMLElement {
   }
 
   async registerTooltip() {
-    if (this.tooltip) {
-      this.tooltip.dispose();
-    }
+    this.disposeTooltip();
     if (this.hash) {
       this.tooltip = await this.addTooltip(this.hash);
+    }
+  }
+
+  disposeTooltip() {
+    if (this.tooltip) {
+      this.tooltip.dispose();
+      this.tooltip = null;
     }
   }
 
@@ -193,9 +192,7 @@ class BlameStatusBarView extends HTMLElement {
   }
 
   addCopiedTooltip(hash) {
-    if (this.tooltip) {
-      this.tooltip.dispose();
-    }
+    this.disposeTooltip();
 
     const copiedTooltip = atom.tooltips.add(this, {
       title: `Copied commit hash: ${hash}`,

--- a/spec/blame-status-bar-spec.js
+++ b/spec/blame-status-bar-spec.js
@@ -91,5 +91,37 @@ describe('Status Bar Blame', () => {
         expect(blameEl().innerHTML).toEqual('<a href="#"><span class="author">Baldur Helgason</span> · <span class="date">2 days ago</span></a>');
       });
     });
+
+    it('should copy the commit hash on shit+click', () => {
+      let spy = null;
+
+      spyOn(utils, 'blame').andReturn([{
+        author: 'Baldur Helgason',
+        date: '2017-04-03 17:05:39 +0000',
+        line: '1',
+        rev: '12345678',
+      }]);
+
+      spyOn(atom.clipboard, 'write');
+      spyOn(BlameView.prototype, 'addTooltip');
+
+      waitsForPromise(() => atom.workspace.open('empty.txt'));
+
+      waitsFor(() => renderSpy.callCount > 0);
+
+      runs(() => {
+        spy = spyOn(BlameView.prototype, 'copyCommitHash').andCallThrough();
+
+        const event = new Event('click');
+        event.shiftKey = true;
+        blameEl().dispatchEvent(event);
+      });
+
+      waitsFor(() => spy.callCount > 0);
+
+      runs(() => {
+        expect(atom.clipboard.write).toHaveBeenCalledWith('12345678');
+      });
+    });
   });
 });


### PR DESCRIPTION
This will implement #7.

I used <kbd>shift</kbd>+click instead of <kbd>command</kbd>/<kbd>ctrl</kbd>+click because the status-bar already implements similar behavior like this (<kbd>shift</kbd>+click on the current path will copy the relative path instead of the absolute path). See: [atom/status-bar/lib/file-info-view.coffee L24](https://github.com/atom/status-bar/blob/9add3a5f4083cc7dee79808811dba74c499a5521/lib/file-info-view.coffee#L24)

The second commit fixes an unrelated bug where hovering over the `Not committed yet` text shows the tooltip from the last cursor position at a commited line.