### PR TITLE
fix-undefined-row: Return when the index of the array does not exists

### DIFF
--- a/lib/editor-handler.js
+++ b/lib/editor-handler.js
@@ -159,6 +159,11 @@ export default class EditorHandler {
     }
 
     this.blameView.editorHandler = this;
+
+    if (!this.blameData[row]) {
+      return;
+    }
+
     this.blameView.render(this.blameData[row]);
     this.registerTooltip();
   }


### PR DESCRIPTION
This change ensures that when the cursor is located in the trailing newline, it does not throw an error on the console.

This is the error: `Uncaught (in promise) TypeError: Cannot read property 'hash' of undefined`